### PR TITLE
FEATURE: Exclude node types from usage count

### DIFF
--- a/Classes/Service/AssetIntegrationService.php
+++ b/Classes/Service/AssetIntegrationService.php
@@ -53,6 +53,12 @@ final class AssetIntegrationService
      */
     protected $assetUsageLogger;
 
+    /**
+     * @Flow\InjectConfiguration(path="excludedNodeTypes")
+     * @var array
+     */
+    protected $excludedNodeTypes;
+
     private $assetPropertiesByNodeType = [];
 
     public function assetRemoved(AssetInterface $asset): void
@@ -102,6 +108,13 @@ final class AssetIntegrationService
     {
         if (array_key_exists($nodeType->getName(), $this->assetPropertiesByNodeType)) {
             return $this->assetPropertiesByNodeType[$nodeType->getName()];
+        }
+
+        foreach ($this->excludedNodeTypes as $excludedNodeType) {
+            if ($nodeType->isOfType($excludedNodeType)) {
+                $this->assetPropertiesByNodeType[$nodeType->getName()] = [];
+                return [];
+            }
         }
 
         $propertyNames = array_reduce(array_keys($nodeType->getProperties()),

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,0 +1,4 @@
+Flowpack:
+  Neos:
+    AssetUsage:
+      excludedNodeTypes: []

--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,29 @@ When that happens, it is important that you try to find out where they come from
 If you think this happened due to an error in this package, please open an issue 
 with as much information as you can give.
 
+## Feature: Exclude node types from usage count
+
+Possible use case: If you are using this package in combination with [neos/metadata-contentrepositoryadapter](https://github.com/neos/metadata-contentrepositoryadapter), the metadata entries will be recognized as usage count. You can adjust this behaviour with the following settings.
+
+Example to exclude all metadata node types from usage count:
+```
+Flowpack:
+  Neos:
+    AssetUsage:
+      excludedNodeTypes:
+        - 'Neos.MetaData:AbstractMetaData'
+```
+
+Example to exclude multiple custom metadata node types:
+```
+Flowpack:
+  Neos:
+    AssetUsage:
+      excludedNodeTypes:
+        - 'Vendor.PackageName:Custom.MetaData.NodeType1'
+        - 'Vendor.PackageName:Custom.MetaData.NodeType2'
+```
+
 ## Related packages
 
 * [Flowpack.EntityUsage](https://github.com/Flowpack/Flowpack.EntityUsage) the generic usage implementation


### PR DESCRIPTION
Add optional configuration for exclusion of node types. Useful in combination with the usage of the package `neos/metadata-contentrepositoryadapter`.

Fixes: #8