### PR TITLE
BUGFIX: Update of usage of previous asset when an asset property is updated

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -16,6 +16,7 @@ namespace Flowpack\Neos\AssetUsage;
 use Flowpack\Neos\AssetUsage\Service\AssetIntegrationService;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\Neos\Service\PublishingService;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Media\Domain\Service\AssetService;
@@ -31,7 +32,7 @@ class Package extends BasePackage
         $dispatcher->connect(Node::class, 'nodePropertyChanged', AssetIntegrationService::class, 'nodePropertyChanged');
         $dispatcher->connect(Node::class, 'nodeRemoved', AssetIntegrationService::class, 'nodeRemoved');
         $dispatcher->connect(Node::class, 'nodeAdded', AssetIntegrationService::class, 'nodeAdded');
-        $dispatcher->connect(Node::class, 'nodeDiscarded', AssetIntegrationService::class, 'nodeDiscarded');
+        $dispatcher->connect(PublishingService::class, 'nodeDiscarded', AssetIntegrationService::class, 'nodeDiscarded');
         $dispatcher->connect(Workspace::class, 'beforeNodePublishing', AssetIntegrationService::class, 'beforeNodePublishing');
         $dispatcher->connect(Workspace::class, 'afterNodePublishing', AssetIntegrationService::class, 'afterNodePublishing');
 

--- a/Classes/Service/AssetIntegrationService.php
+++ b/Classes/Service/AssetIntegrationService.php
@@ -217,7 +217,7 @@ final class AssetIntegrationService
                 return;
             }
             $propertyValue = $node->getProperty($propertyName);
-            if (!$propertyValue) {
+            if (empty($propertyValue)) {
                 return;
             }
             $this->unregisterUsageInNode($node, $propertyValue, false);
@@ -310,15 +310,11 @@ final class AssetIntegrationService
      */
     public function nodePropertyChanged(NodeInterface $node, string $propertyName, $oldValue, $newValue): void
     {
-        if ($this->propertyTypeCanBeRegistered($node->getNodeType()->getPropertyType($propertyName)) && $oldValue && empty($newValue)) {
-            $this->unregisterUsageInNode($node, $oldValue);
-        }
-
         if ($oldValue === $newValue || !$this->propertyTypeCanBeRegistered($node->getNodeType()->getPropertyType($propertyName))) {
             return;
         }
 
-        if ($oldValue && $newValue) {
+        if ($oldValue) {
             $this->unregisterUsageInNode($node, $oldValue);
         }
 

--- a/Classes/Service/AssetIntegrationService.php
+++ b/Classes/Service/AssetIntegrationService.php
@@ -205,19 +205,20 @@ final class AssetIntegrationService
         $targetNode = $contentContext->getNodeByIdentifier($node->getIdentifier());
 
         foreach ($this->getAssetPropertyNamesForNodeType($node->getNodeType()) as $propertyName) {
-            if (!$node->hasProperty($propertyName)) {
-                return;
-            }
-            $propertyValue = $node->getProperty($propertyName);
-            if (!$propertyValue) {
-                return;
-            }
             // Unregister the asset stored in the target node, the assets will be registered again after publishing
             if ($targetNode && $targetNode->hasProperty($propertyName)) {
                 $targetPropertyValue = $targetNode->getProperty($propertyName);
                 if ($targetPropertyValue) {
                     $this->unregisterUsageInNode($targetNode, $targetPropertyValue, false);
                 }
+            }
+
+            if (!$node->hasProperty($propertyName)) {
+                return;
+            }
+            $propertyValue = $node->getProperty($propertyName);
+            if (!$propertyValue) {
+                return;
             }
             $this->unregisterUsageInNode($node, $propertyValue, false);
         }
@@ -309,11 +310,15 @@ final class AssetIntegrationService
      */
     public function nodePropertyChanged(NodeInterface $node, string $propertyName, $oldValue, $newValue): void
     {
+        if ($this->propertyTypeCanBeRegistered($node->getNodeType()->getPropertyType($propertyName)) && $oldValue && empty($newValue)) {
+            $this->unregisterUsageInNode($node, $oldValue);
+        }
+
         if ($oldValue === $newValue || !$this->propertyTypeCanBeRegistered($node->getNodeType()->getPropertyType($propertyName))) {
             return;
         }
 
-        if ($oldValue) {
+        if ($oldValue && $newValue) {
             $this->unregisterUsageInNode($node, $oldValue);
         }
 


### PR DESCRIPTION
Currently if you replace or remove an image from a node the asset usage of the first used image is not updated, when the changes are published. For example if an image is added to a node the usage is correctly set to 1. When this image is then replaced by an other image, the asset usage of the first image stays as 1 and the second image gets a correct asset usage of 1. The expected behaviour is, that the asset usage of the first image should go from 1 to 0.
  
In this pr the correct class for the `nodeDiscarded` Signal (see here https://github.com/Flowpack/Flowpack.Neos.AssetUsage/pull/11/files#diff-69e3e8da81e0c1cc4f7aff2f36a95d4d52edd92ea5628b312a09970b77cf5868R35) is added and the code order in the `beforeNodePublishing` function is adjusted. The the old image usage needs to be update (see here https://github.com/Flowpack/Flowpack.Neos.AssetUsage/pull/11/files#diff-ad82dc394f028c9fdc2b8d83ceb45b47980d9b94954827a3126feab8b1afb102L216) before one can check whether a new image is added (see the checks here https://github.com/Flowpack/Flowpack.Neos.AssetUsage/pull/11/files#diff-ad82dc394f028c9fdc2b8d83ceb45b47980d9b94954827a3126feab8b1afb102R216).
With these changes the asset usage for the old image is updated correctly, when a replacement or removal of this image is published. I think, this pr should also fix the issue https://github.com/Flowpack/Flowpack.Neos.AssetUsage/issues/2 .