### PR TITLE
BUGFIX: Changing a node with multiple asset properties take all properties int account

### DIFF
--- a/Classes/Service/AssetIntegrationService.php
+++ b/Classes/Service/AssetIntegrationService.php
@@ -94,11 +94,11 @@ final class AssetIntegrationService
         }
         foreach ($this->getAssetPropertyNamesForNodeType($node->getNodeType()) as $propertyName) {
             if (!$node->hasProperty($propertyName)) {
-                return;
+                continue;
             }
             $propertyValue = $node->getProperty($propertyName);
             if (!$propertyValue) {
-                return;
+                continue;
             }
             $this->registerUsageInNode($node, $propertyValue);
         }
@@ -214,11 +214,11 @@ final class AssetIntegrationService
             }
 
             if (!$node->hasProperty($propertyName)) {
-                return;
+                continue;
             }
             $propertyValue = $node->getProperty($propertyName);
             if (empty($propertyValue)) {
-                return;
+                continue;
             }
             $this->unregisterUsageInNode($node, $propertyValue, false);
         }
@@ -280,7 +280,7 @@ final class AssetIntegrationService
     {
         foreach ($this->getAssetPropertyNamesForNodeType($node->getNodeType()) as $propertyName) {
             if (!$node->hasProperty($propertyName)) {
-                return;
+                continue;
             }
             $propertyValue = $node->getProperty($propertyName);
             if ($propertyValue) {
@@ -293,7 +293,7 @@ final class AssetIntegrationService
     {
         foreach ($this->getAssetPropertyNamesForNodeType($node->getNodeType()) as $propertyName) {
             if (!$node->hasProperty($propertyName)) {
-                return;
+                continue;
             }
             $propertyValue = $node->getProperty($propertyName);
             if ($propertyValue) {


### PR DESCRIPTION
BUGFIX: When publishing, adding or removing a node with multiple asset properties of which only some are set, check all properties and not return if the first property is not set